### PR TITLE
Create Team Score Entity

### DIFF
--- a/src/FootballWorldCupScoreBoard.Application/TeamScore.cs
+++ b/src/FootballWorldCupScoreBoard.Application/TeamScore.cs
@@ -11,6 +11,9 @@ public record TeamScore
 
     public void Increase()
     {
-        Score++;
+        checked
+        {
+            Score++;
+        }
     }
 }

--- a/src/FootballWorldCupScoreBoard.Application/TeamScore.cs
+++ b/src/FootballWorldCupScoreBoard.Application/TeamScore.cs
@@ -1,0 +1,11 @@
+﻿namespace FootballWorldCupScoreBoard.Application;
+
+public record TeamScore
+{
+    public Team Team { get; init; } = null!;
+    public byte Score { get; init; }
+
+    private TeamScore() { }
+
+    public static TeamScore CreateFor(Team team) => new() { Team = team, Score = 0 };
+}

--- a/src/FootballWorldCupScoreBoard.Application/TeamScore.cs
+++ b/src/FootballWorldCupScoreBoard.Application/TeamScore.cs
@@ -3,9 +3,14 @@
 public record TeamScore
 {
     public Team Team { get; init; } = null!;
-    public byte Score { get; init; }
+    public byte Score { get; private set; }
 
     private TeamScore() { }
 
     public static TeamScore CreateFor(Team team) => new() { Team = team, Score = 0 };
+
+    public void Increase()
+    {
+        Score = 1;
+    }
 }

--- a/src/FootballWorldCupScoreBoard.Application/TeamScore.cs
+++ b/src/FootballWorldCupScoreBoard.Application/TeamScore.cs
@@ -11,6 +11,6 @@ public record TeamScore
 
     public void Increase()
     {
-        Score = 1;
+        Score++;
     }
 }

--- a/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
+++ b/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
@@ -35,4 +35,25 @@ public class TeamScoreTests
         // Assert
         sut.Score.Should().Be(1);
     }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(5)]
+    [InlineData(255)]
+    public void Increment_WhenInvokedMoreThanOnce_ShouldSetScoreToAmountOfInvocationTimes(
+        byte times
+    )
+    {
+        // Arrange
+        var sut = TeamScore.CreateFor(AnyTeam);
+
+        // Act
+        for (var _ = 0; _ < times; _++)
+        {
+            sut.Increase();
+        }
+
+        // Assert
+        sut.Score.Should().Be(times);
+    }
 }

--- a/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
+++ b/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
@@ -4,6 +4,7 @@ namespace FootballWorldCupScoreBoard.Application.Tests;
 
 public class TeamScoreTests
 {
+    private const int MoreThanByteCanStore = byte.MaxValue + 1;
     private const string AnyName = "Italy";
     private static readonly Team AnyTeam = Team.Create(AnyName);
 
@@ -53,5 +54,24 @@ public class TeamScoreTests
 
         // Assert
         sut.Score.Should().Be(times);
+    }
+
+    [Fact]
+    public void Increase_WhenScoreMoreThan255_ShouldThrowOverflowException()
+    {
+        // Arrange
+        var sut = TeamScore.CreateFor(AnyTeam);
+
+        // Act
+        var action = () =>
+        {
+            for (var _ = 0; _ < MoreThanByteCanStore; _++)
+            {
+                sut.Increase();
+            }
+        };
+
+        // Assert
+        action.Should().ThrowExactly<OverflowException>();
     }
 }

--- a/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
+++ b/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
@@ -1,0 +1,25 @@
+﻿using FluentAssertions;
+
+namespace FootballWorldCupScoreBoard.Application.Tests;
+
+public class TeamScoreTests
+{
+    private const string AnyName = "Italy";
+    private static readonly Team AnyTeam = Team.Create(AnyName);
+
+    [Fact]
+    public void CreateFor_Always_ShouldReturnTeamScore()
+    {
+        // Act
+        var actual = TeamScore.CreateFor(AnyTeam);
+
+        // Assert
+        actual
+            .Should()
+            .NotBeNull()
+            .And
+            .BeOfType<TeamScore>()
+            .And
+            .BeEquivalentTo(new { Team = new { Name = AnyName }, Score = 0 });
+    }
+}

--- a/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
+++ b/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
@@ -22,4 +22,17 @@ public class TeamScoreTests
             .And
             .BeEquivalentTo(new { Team = new { Name = AnyName }, Score = 0 });
     }
+
+    [Fact]
+    public void Increment_WhenInvokedOneTime_ShouldSetScoreToOne()
+    {
+        // Arrange
+        var sut = TeamScore.CreateFor(AnyTeam);
+
+        // Act
+        sut.Increase();
+
+        // Assert
+        sut.Score.Should().Be(1);
+    }
 }

--- a/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
+++ b/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
@@ -12,7 +12,7 @@ public class TeamScoreTests
     public void CreateFor_Always_ShouldReturnTeamScore()
     {
         // Act
-        var actual = TeamScore.CreateFor(AnyTeam);
+        var actual = CreateSut();
 
         // Assert
         actual
@@ -28,7 +28,7 @@ public class TeamScoreTests
     public void Increase_WhenInvokedOneTime_ShouldSetScoreToOne()
     {
         // Arrange
-        var sut = TeamScore.CreateFor(AnyTeam);
+        var sut = CreateSut();
 
         // Act
         sut.Increase();
@@ -44,13 +44,10 @@ public class TeamScoreTests
     public void Increase_WhenInvokedMoreThanOnce_ShouldSetScoreToAmountOfInvocationTimes(byte times)
     {
         // Arrange
-        var sut = TeamScore.CreateFor(AnyTeam);
+        var sut = CreateSut();
 
         // Act
-        for (var _ = 0; _ < times; _++)
-        {
-            sut.Increase();
-        }
+        RepeatIncreaseFor(sut, times);
 
         // Assert
         sut.Score.Should().Be(times);
@@ -60,18 +57,22 @@ public class TeamScoreTests
     public void Increase_WhenScoreMoreThan255_ShouldThrowOverflowException()
     {
         // Arrange
-        var sut = TeamScore.CreateFor(AnyTeam);
+        var sut = CreateSut();
 
         // Act
-        var action = () =>
-        {
-            for (var _ = 0; _ < MoreThanByteCanStore; _++)
-            {
-                sut.Increase();
-            }
-        };
+        var action = () => RepeatIncreaseFor(sut, MoreThanByteCanStore);
 
         // Assert
         action.Should().ThrowExactly<OverflowException>();
+    }
+
+    private static TeamScore CreateSut() => TeamScore.CreateFor(AnyTeam);
+
+    private static void RepeatIncreaseFor(TeamScore teamScore, int times)
+    {
+        for (var _ = 0; _ < times; _++)
+        {
+            teamScore.Increase();
+        }
     }
 }

--- a/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
+++ b/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
@@ -24,7 +24,7 @@ public class TeamScoreTests
     }
 
     [Fact]
-    public void Increment_WhenInvokedOneTime_ShouldSetScoreToOne()
+    public void Increase_WhenInvokedOneTime_ShouldSetScoreToOne()
     {
         // Arrange
         var sut = TeamScore.CreateFor(AnyTeam);
@@ -40,9 +40,7 @@ public class TeamScoreTests
     [InlineData(2)]
     [InlineData(5)]
     [InlineData(255)]
-    public void Increment_WhenInvokedMoreThanOnce_ShouldSetScoreToAmountOfInvocationTimes(
-        byte times
-    )
+    public void Increase_WhenInvokedMoreThanOnce_ShouldSetScoreToAmountOfInvocationTimes(byte times)
     {
         // Arrange
         var sut = TeamScore.CreateFor(AnyTeam);


### PR DESCRIPTION
The `TeamScore` entity wraps specific `Team`sand `Score` together.
This approach allows for independently increasing each score and making next `Match` entity