### PR TITLE
Add .ToString() implementation for team score

### DIFF
--- a/src/FootballWorldCupScoreBoard.Application/TeamScore.cs
+++ b/src/FootballWorldCupScoreBoard.Application/TeamScore.cs
@@ -16,4 +16,6 @@ public record TeamScore
             Score++;
         }
     }
+
+    public override string ToString() => $"{Team} {Score}";
 }

--- a/src/FootballWorldCupScoreBoard.Application/TeamScore.cs
+++ b/src/FootballWorldCupScoreBoard.Application/TeamScore.cs
@@ -7,8 +7,6 @@ public record TeamScore
 
     private TeamScore() { }
 
-    public static TeamScore CreateFor(Team team) => new() { Team = team, Score = 0 };
-
     public void Increase()
     {
         checked
@@ -18,4 +16,6 @@ public record TeamScore
     }
 
     public override string ToString() => $"{Team} {Score}";
+
+    public static TeamScore CreateFor(Team team) => new() { Team = team, Score = 0 };
 }

--- a/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
+++ b/tests/FootballWorldCupScoreBoard.Application.Tests/TeamScoreTests.cs
@@ -52,6 +52,18 @@ public class TeamScoreTests
         action.Should().ThrowExactly<OverflowException>();
     }
 
+    [Theory]
+    [InlineData(1)]
+    [InlineData(3)]
+    public void ToString_Always_ShouldReturnTeamNameAndScore(int times)
+    {
+        // Arrange
+        RepeatIncreaseFor(_sut, times);
+
+        // Act & Assert
+        _sut.ToString().Should().Be($"{AnyName} {times}");
+    }
+
     private static void RepeatIncreaseFor(TeamScore teamScore, int times)
     {
         for (var _ = 0; _ < times; _++)


### PR DESCRIPTION
- Decreases debug complexity
- Simplifies the visibility of the score

Using `Team.Name` & `Score` constructs value: `"Name Score"`