### PR TITLE
Add summary recorder

### DIFF
--- a/src/FootballWorldCupScoreBoard.Persistence/DependencyInjectionExtensions.cs
+++ b/src/FootballWorldCupScoreBoard.Persistence/DependencyInjectionExtensions.cs
@@ -5,5 +5,5 @@ namespace FootballWorldCupScoreBoard.Persistence;
 public static class DependencyInjectionExtensions
 {
     public static IServiceCollection AddPersistence(this IServiceCollection services) =>
-        services.AddSingleton<DatabaseContext>();
+        services.AddSingleton<DatabaseContext>().AddTransient<IGuidProvider, GuidProvider>();
 }

--- a/src/FootballWorldCupScoreBoard.Persistence/FootballWorldCupScoreBoard.Persistence.csproj
+++ b/src/FootballWorldCupScoreBoard.Persistence/FootballWorldCupScoreBoard.Persistence.csproj
@@ -10,4 +10,8 @@
       <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
     </ItemGroup>
 
+    <ItemGroup>
+      <ProjectReference Include="..\FootballWorldCupScoreBoard.Application\FootballWorldCupScoreBoard.Application.csproj" />
+    </ItemGroup>
+
 </Project>

--- a/src/FootballWorldCupScoreBoard.Persistence/Games/GameModel.cs
+++ b/src/FootballWorldCupScoreBoard.Persistence/Games/GameModel.cs
@@ -7,7 +7,7 @@ public class GameModel
 {
     public Guid Guid { get; set; }
     public string HomeTeamName { get; set; } = null!;
-    public string HomeTeamScore { get; set; } = null!;
+    public byte HomeTeamScore { get; set; }
     public string AwayTeamName { get; set; } = null!;
-    public string AwayTeamScore { get; set; } = null!;
+    public byte AwayTeamScore { get; set; }
 }

--- a/src/FootballWorldCupScoreBoard.Persistence/Games/GameRepository.cs
+++ b/src/FootballWorldCupScoreBoard.Persistence/Games/GameRepository.cs
@@ -1,0 +1,29 @@
+﻿using FootballWorldCupScoreBoard.Application.Matches;
+using FootballWorldCupScoreBoard.Application.Scoring;
+
+namespace FootballWorldCupScoreBoard.Persistence.Games;
+
+public class GameRepository : ISummaryRecorder
+{
+    private readonly DatabaseContext _context;
+    private readonly IGuidProvider _guidProvider;
+
+    public GameRepository(DatabaseContext context, IGuidProvider guidProvider)
+    {
+        _context = context;
+        _guidProvider = guidProvider;
+    }
+
+    public void SaveMatch(IMatch match) =>
+        _context
+            .Games
+            .Add(
+                new GameModel
+                {
+                    HomeTeamName = match.HomeTeam.Name,
+                    HomeTeamScore = match.HomeTeamScore,
+                    AwayTeamName = match.AwayTeam.Name,
+                    AwayTeamScore = match.AwayTeamScore,
+                }
+            );
+}

--- a/src/FootballWorldCupScoreBoard.Persistence/Games/GameRepository.cs
+++ b/src/FootballWorldCupScoreBoard.Persistence/Games/GameRepository.cs
@@ -20,6 +20,7 @@ public class GameRepository : ISummaryRecorder
             .Add(
                 new GameModel
                 {
+                    Guid = _guidProvider.NewGuid(),
                     HomeTeamName = match.HomeTeam.Name,
                     HomeTeamScore = match.HomeTeamScore,
                     AwayTeamName = match.AwayTeam.Name,

--- a/src/FootballWorldCupScoreBoard.Persistence/GuidProvider.cs
+++ b/src/FootballWorldCupScoreBoard.Persistence/GuidProvider.cs
@@ -1,0 +1,9 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace FootballWorldCupScoreBoard.Persistence;
+
+[ExcludeFromCodeCoverage(Justification = "Wrapping static functionality")]
+public class GuidProvider : IGuidProvider
+{
+    public Guid NewGuid() => Guid.NewGuid();
+}

--- a/src/FootballWorldCupScoreBoard.Persistence/IGuidProvider.cs
+++ b/src/FootballWorldCupScoreBoard.Persistence/IGuidProvider.cs
@@ -1,0 +1,6 @@
+﻿namespace FootballWorldCupScoreBoard.Persistence;
+
+public interface IGuidProvider
+{
+    Guid NewGuid();
+}

--- a/tests/FootballWorldCupScoreBoard.Persistence.UnitTests/FootballWorldCupScoreBoard.Persistence.UnitTests.csproj
+++ b/tests/FootballWorldCupScoreBoard.Persistence.UnitTests/FootballWorldCupScoreBoard.Persistence.UnitTests.csproj
@@ -16,6 +16,7 @@
         </PackageReference>
         <PackageReference Include="FluentAssertions" Version="7.0.0-alpha.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+        <PackageReference Include="Moq" Version="4.20.70" />
         <PackageReference Include="xunit" Version="2.4.2" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/FootballWorldCupScoreBoard.Persistence.UnitTests/Games/GameRepositoryTests.cs
+++ b/tests/FootballWorldCupScoreBoard.Persistence.UnitTests/Games/GameRepositoryTests.cs
@@ -1,0 +1,75 @@
+﻿using FluentAssertions;
+using FluentAssertions.Execution;
+using FootballWorldCupScoreBoard.Application;
+using FootballWorldCupScoreBoard.Application.Matches;
+using FootballWorldCupScoreBoard.Persistence.Games;
+using Moq;
+
+namespace FootballWorldCupScoreBoard.Persistence.UnitTests.Games;
+
+public class GameRepositoryTests
+{
+    private readonly DatabaseContext _context = new();
+    private readonly Mock<IGuidProvider> _guidProviderMock = new();
+    private readonly GameRepository _sut;
+
+    public GameRepositoryTests()
+    {
+        _sut = new GameRepository(_context, _guidProviderMock.Object);
+    }
+
+    [Fact]
+    public void SaveMatch_Always_ShouldAddToGameCollection()
+    {
+        // Arrange
+        var match = new MatchStub("England", 3, "Germany", 2);
+
+        // Act
+        _sut.SaveMatch(match);
+
+        // Assert
+        using (new AssertionScope())
+        {
+            _context.Games.Should().HaveCount(1);
+            _context
+                .Games
+                .First()
+                .Should()
+                .BeEquivalentTo(
+                    new
+                    {
+                        Guid = Guid.Empty,
+                        HomeTeamName = "England",
+                        HomeTeamScore = 3,
+                        AwayTeamName = "Germany",
+                        AwayTeamScore = 2
+                    }
+                );
+        }
+    }
+
+    private class MatchStub : IMatch
+    {
+        public MatchStub(
+            string homeTeamName,
+            byte homeTeamScore,
+            string awayTeamName,
+            byte awayTeamScore
+        )
+        {
+            HomeTeam = Team.Create(homeTeamName);
+            HomeTeamScore = homeTeamScore;
+            AwayTeam = Team.Create(awayTeamName);
+            AwayTeamScore = awayTeamScore;
+        }
+
+        public Team HomeTeam { get; }
+        public byte HomeTeamScore { get; }
+        public Team AwayTeam { get; }
+        public byte AwayTeamScore { get; }
+
+        public void HomeTeamScoresGoal() => throw new NotImplementedException();
+
+        public void AwayTeamScoresGoal() => throw new NotImplementedException();
+    }
+}

--- a/tests/FootballWorldCupScoreBoard.Persistence.UnitTests/Games/GameRepositoryTests.cs
+++ b/tests/FootballWorldCupScoreBoard.Persistence.UnitTests/Games/GameRepositoryTests.cs
@@ -9,6 +9,9 @@ namespace FootballWorldCupScoreBoard.Persistence.UnitTests.Games;
 
 public class GameRepositoryTests
 {
+    private static readonly Guid SomeRandomGuid = Guid.Parse(
+        "dce522fb-8977-4a36-a296-4aa65751b308"
+    );
     private readonly DatabaseContext _context = new();
     private readonly Mock<IGuidProvider> _guidProviderMock = new();
     private readonly GameRepository _sut;
@@ -23,6 +26,7 @@ public class GameRepositoryTests
     {
         // Arrange
         var match = new MatchStub("England", 3, "Germany", 2);
+        _guidProviderMock.Setup(x => x.NewGuid()).Returns(SomeRandomGuid);
 
         // Act
         _sut.SaveMatch(match);
@@ -38,7 +42,7 @@ public class GameRepositoryTests
                 .BeEquivalentTo(
                     new
                     {
-                        Guid = Guid.Empty,
+                        Guid = SomeRandomGuid,
                         HomeTeamName = "England",
                         HomeTeamScore = 3,
                         AwayTeamName = "Germany",


### PR DESCRIPTION
Summary recorder is a repository that saves matches into in-memory collection (representing data operations)